### PR TITLE
EOEPCA-824 resource catalogue path ingress

### DIFF
--- a/charts/rm-resource-catalogue/Chart.yaml
+++ b/charts/rm-resource-catalogue/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rm-resource-catalogue/templates/resource-catalogue-ingress.yaml
+++ b/charts/rm-resource-catalogue/templates/resource-catalogue-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
-    {{- if .Values.ingress.subpath_enabled -}}
+    {{- if .Values.ingress.subpath_enabled }}
     {{- with .Values.ingress.subpath_annotations }}
       {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
@@ -30,7 +30,7 @@ spec:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
-      {{- if .Values.ingress.subpath_enabled -}}
+      {{- if .Values.ingress.subpath_enabled }}
       - path: {{ .Values.ingress.subpath }}/(.*)
         {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
         pathType: Prefix
@@ -59,7 +59,7 @@ spec:
           serviceName: {{ .Values.pycsw.service_name }}
           servicePort: {{ .Values.pycsw.service_port }}
           {{- end }}
-      {{- else -}}
+      {{- else }}
       - path:
         {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
         pathType: "ImplementationSpecific"


### PR DESCRIPTION
Tested chart `1.2.1`...

```
helm template resource-catalogue rm-resource-catalogue --version 1.2.1 --repo https://eoepca.github.io/helm-charts-dev/ -f ./values.yaml --debug
```

with values...

```
global:
  namespace: rm
ingress:
  enabled: true
  name: resource-catalogue
  host: 185-52-193-246.nip.io
  subpath_enabled: true
  subpath: "/resource-catalogue"
  # we're not using tls, but the resource-catalogue helm chart insists on
  # having values anyway - so may as well set consistent values
  tls_host: 185-52-193-246.nip.io
  tls_secret_name: resource-catalogue-tls
  annotations:
    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
db:
  volume_storage_type: standard
pycsw:
  config:
    server:
      url: http://185-52-193-246.nip.io/resource-catalogue/
```

But there is an error due to missing line-ending in the yaml around the `path` elements...

```
spec:
  rules:
  - host: 185-52-193-246.nip.io
    http:
      paths:- path: /resource-catalogue/(.*)
        pathType: Prefix
        backend:
          service:
            name: resource-catalogue-service
            port:
              number: 80
```

Attached patch appears to fix this.