### PR TITLE
[registration-harvester] add optional eodata mount

### DIFF
--- a/charts/registration-harvester/Chart.yaml
+++ b/charts/registration-harvester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-rc2.1
+version: 2.0.0-rc2-pr-63
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/registration-harvester/Chart.yaml
+++ b/charts/registration-harvester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-rc2
+version: 2.0.0-rc2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/registration-harvester/Chart.yaml
+++ b/charts/registration-harvester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-rc2-pr-63
+version: 2.0.0-rc2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/registration-harvester/templates/registration-harvester-deployment.yaml
+++ b/charts/registration-harvester/templates/registration-harvester-deployment.yaml
@@ -47,8 +47,17 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.harvester.volume_path }}
           name: {{ .Values.harvester.volume_name }}
+        {{- if .Values.harvester.eodata.enabled }}
+        - mountPath: {{ .Values.harvester.eodata.mountPath }}
+          name: {{ .Values.harvester.eodata.volumeName }}
+        {{- end }}
       restartPolicy: Always
       volumes:
       - name: {{ .Values.harvester.volume_name }}
         configMap:
           name: {{ .Release.Name }}-configmap
+      {{- if .Values.harvester.eodata.enabled }}
+      - name: {{ .Values.harvester.eodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.harvester.eodata.claimName }}
+      {{- end }}

--- a/charts/registration-harvester/templates/registration-harvester-eodata-pvc.yaml
+++ b/charts/registration-harvester/templates/registration-harvester-eodata-pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.harvester.eodata.enabled .Values.harvester.eodata.createPVC }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.harvester.eodata.claimName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/component: eodata-storage
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  {{- if .Values.harvester.eodata.reuseExistingVolume }}
+  volumeName: {{ .Values.harvester.eodata.reuseExistingVolume }}
+  {{- end }}
+  accessModes:
+    - {{ .Values.harvester.eodata.accessMode | default "ReadWriteMany" }}
+  storageClassName: {{ .Values.harvester.eodata.storageClass | default "standard" }}
+  resources:
+    requests:
+      storage: {{ .Values.harvester.eodata.size | default "100Gi" }}
+{{- end }}

--- a/charts/registration-harvester/values.yaml
+++ b/charts/registration-harvester/values.yaml
@@ -23,3 +23,13 @@ harvester:
         cacert: ""
       topics:
       handlers:
+  eodata:
+    enabled: false
+    createPVC: true
+    # reuseExistingVolume: existing-pv-name  # optional override
+    claimName: eodata
+    volumeName: eodata
+    mountPath: /eodata
+    accessMode: ReadWriteMany
+    storageClass: standard
+    size: 100Gi


### PR DESCRIPTION
Update registration-harvester helm chart to allow provision of `/eodata` as a volume - e.g. for use of shared storage.