### PR TITLE
feat(iam-bb): add configurable CORS for Keycloak route.

### DIFF
--- a/charts/iam-bb/README.md
+++ b/charts/iam-bb/README.md
@@ -281,6 +281,31 @@ By default, secrets are generated automatically. If `clientSecretRef`
 is used to reference an existing secret, this secret may contain further
 parameters like the client ID.
 
+
+### CORS Configuration
+
+Enable CORS for JavaScript applications from different domains to authenticate with Keycloak.
+
+| Parameter                         | Default        | Description                                             |
+|-----------------------------------|----------------|---------------------------------------------------------|
+| `keycloak.cors.enabled`           | `false`        | Enable CORS for Keycloak route                          |
+| `keycloak.cors.allowedOrigins`    | `[]`           | List of allowed origins. Empty list defaults to `*`     |
+| `keycloak.cors.allowCredentials`  | `true`         | Allow credentials (cookies, auth headers) in requests   |
+
+**Note:** When credentials are enabled with specific origins, browsers reject wildcard `*`. List all origins explicitly for multi-tenant setups.
+
+#### Example
+
+```yaml
+keycloak:
+  cors:
+    enabled: true
+    allowedOrigins:
+      - https://eoapi.develop.eoepca.org
+      - https://another-app.develop.eoepca.org
+    allowCredentials: true
+```
+
 ### Handling of secrets
 
 The Helm chart supports four approaches to specify or generate client

--- a/charts/iam-bb/templates/apisixroute-keycloak.yaml
+++ b/charts/iam-bb/templates/apisixroute-keycloak.yaml
@@ -24,6 +24,21 @@ spec:
       # Allow CORS access
       - name: cors
         enable: true
+        config:
+{{- if .Values.keycloak.cors.allowedOrigins }}
+          allow_origins: {{- .Values.keycloak.cors.allowedOrigins | toJson | nindent 12 }}
+{{- else }}
+          allow_origins: "*"
+{{- end }}
+          allow_methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
+          allow_headers: "*"
+          expose_headers: "*"
+{{- if and .Values.keycloak.cors.allowedOrigins .Values.keycloak.cors.allowCredentials }}
+          allow_credential: true
+{{- else }}
+          allow_credential: false
+{{- end }}
+          max_age: 3600
 {{- end }}
 # The following workaround has been replaced with a global rule and is not needed here any more.
 #    plugins:

--- a/charts/iam-bb/values.yaml
+++ b/charts/iam-bb/values.yaml
@@ -160,6 +160,11 @@ keycloak:
   cors:
     # Set this to true to enable CORS
     enabled: false
+    # List of allowed origins. Empty defaults to '*'.
+    # Note: Credentials require specific origins (not '*').
+    allowedOrigins: []
+    # Allow credentials (cookies, authorization headers)
+    allowCredentials: true
   ## @param production Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.
   ##
   production: false
@@ -445,7 +450,7 @@ opal:
           input.path in [[""], ["health"]]
           print("GET /, Input: ", input)
         }
-        # Claims from JWT if JWT is present and can be verified; null otherwise 
+        # Claims from JWT if JWT is present and can be verified; null otherwise
         default verified_claims = null
         verified_claims := claims if {
           [type, token] := split(input.headers["Authorization"][_], " ")
@@ -467,14 +472,14 @@ opal:
           print("AuthZ unset, Input: ", input)
         }
         allow if {
-          # Allow authenticated users to evaluate policies 
+          # Allow authenticated users to evaluate policies
           claims := verified_claims
           claims != null
           allow_policy_evaluation == true
           print("External, Input: ", input, " Claims: ", claims)
         }
         allow if {
-          # Allow selected users to GET arbitrary URLs 
+          # Allow selected users to GET arbitrary URLs
           claims := verified_claims
           claims.email in ["privileged_user@nowhere.com"]
           input.method = "GET"


### PR DESCRIPTION
Related to: https://github.com/EOEPCA/resource-discovery/issues/228

This PR proposes to add configurable CORS support for the Keycloak route to enable JavaScript applications from different domains to authenticate directly.

- Add `keycloak.cors.allowedOrigins` parameter (defaults to `*` when empty)
- Add `keycloak.cors.allowCredentials` parameter (defaults to `true`)
- Configure APISIX CORS plugin with proper security (credentials require specific origins)

## Example usage
```yaml
keycloak:
  cors:
    enabled: true
    allowedOrigins:
      - https://eoapi.develop.eoepca.org
      - https://another-app.develop.eoepca.org
    allowCredentials: true
