### PR TITLE
Deprecate disused charts before deletion.

### DIFF
--- a/charts/ades/Chart.yaml
+++ b/charts/ades/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.24
+version: 2.0.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 2.0.21
+
+# We now use the upstream charts from https://zoo-project.github.io/charts/
+deprecated: true

--- a/charts/billing-service/Chart.yaml
+++ b/charts/billing-service/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0
+
+# Development never completed for this service
+deprecated: true

--- a/charts/cheese/Chart.yaml
+++ b/charts/cheese/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0.0
+
+# Test app no longer required.
+deprecated: true

--- a/charts/data-access/Chart.yaml
+++ b/charts/data-access/Chart.yaml
@@ -15,13 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.4.1"
+version: "1.4.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "4.1.3"
+
+# Test app no longer required.
+deprecated: true
 
 dependencies:
   #-----------------------------------------------------------------------------

--- a/charts/django-portal/Chart.yaml
+++ b/charts/django-portal/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 2022.05.05.08.25
+
+# Service no longer being developed
+deprecated: true

--- a/charts/dummy/Chart.yaml
+++ b/charts/dummy/Chart.yaml
@@ -15,10 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.0.0"
+
+# Test service which is no longer required
+deprecated: true

--- a/charts/eoapi-maps-plugin/Chart.yaml
+++ b/charts/eoapi-maps-plugin/Chart.yaml
@@ -4,5 +4,8 @@ description: A Helm chart containing a deployment of pygeoapi and eoapi-maps-plu
 
 type: application
 
-version: 0.0.21
+version: 0.0.22
 appVersion: 0.0.18
+
+# eoapi-maps-plugin no longer required
+deprecated: true

--- a/charts/eoepca-portal/Chart.yaml
+++ b/charts/eoepca-portal/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: v1.4.1
+
+# Service deprecated
+deprecated: true

--- a/charts/identity-gatekeeper/Chart.yaml
+++ b/charts/identity-gatekeeper/Chart.yaml
@@ -15,10 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "2.8.0"
+
+# Service no longer used in EOEPCA - APISIX plugin used instead
+deprecated: true

--- a/charts/identity-service/Chart.yaml
+++ b/charts/identity-service/Chart.yaml
@@ -16,12 +16,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.98
+version: 1.0.99
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "v1"
+
+# Replaced with iam-bb
+deprecated: true
 
 dependencies:
   - name: identity-keycloak

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -15,9 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0.0
+
+# Jupyter now managed by app hub
+deprecated: true
+

--- a/charts/license-manager/Chart.yaml
+++ b/charts/license-manager/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0
+
+# Service was never developed.
+deprecated: true

--- a/charts/login-service/Chart.yaml
+++ b/charts/login-service/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using. 
 appVersion: "v1.1.4"
+
+# Replaced with iam-bb.
+deprecated: true

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 19
+
+# Service no longer used in EOEPCA
+deprecated: true

--- a/charts/nfs-provisioner/Chart.yaml
+++ b/charts/nfs-provisioner/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "v4.0.0"
+
+# Upstream charts should be used instead
+deprecated: true

--- a/charts/pde-jupyterhub/Chart.yaml
+++ b/charts/pde-jupyterhub/Chart.yaml
@@ -1,7 +1,7 @@
 # Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
 apiVersion: v2
 name: jupyterhub
-version: 1.1.12
+version: 1.1.13
 appVersion: 2.0.2
 description: Multi-user Jupyter installation
 keywords: [jupyter, jupyterhub, z2jh]
@@ -9,6 +9,10 @@ home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: ">=1.17.0-0"
+
+# Upstream chart used instead
+deprecated: true
+
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/charts/pdp-engine/Chart.yaml
+++ b/charts/pdp-engine/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.13
+version: 1.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "v1.2"
+
+# Replaced with OPA+OPAL
+deprecated: true

--- a/charts/pep-engine/Chart.yaml
+++ b/charts/pep-engine/Chart.yaml
@@ -16,10 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.11
+version: 1.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # appVersion: "v0.9.2"
 appVersion: "v1.2"
+
+# Replaced with APISIX plugins
+deprecated: true

--- a/charts/pricing-engine/Chart.yaml
+++ b/charts/pricing-engine/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0
+
+# Component never developed.
+deprecated: true

--- a/charts/resource-guard/Chart.yaml
+++ b/charts/resource-guard/Chart.yaml
@@ -15,13 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "u1.2.5:p1.1.11"
+
+# Replaced with iam-bb and APISIX plugins
+deprecated: true
 
 dependencies:
   #-----------------------------------------------------------------------------

--- a/charts/rm-bucket-operator-wrapper/Chart.yaml
+++ b/charts/rm-bucket-operator-wrapper/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 0.0.1
+
+# Replaced with Crossplane
+deprecated: true

--- a/charts/rm-bucket-operator/Chart.yaml
+++ b/charts/rm-bucket-operator/Chart.yaml
@@ -15,10 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.12
+version: 0.9.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: 1.1.0
+
+# Replaced with Crossplane
+deprecated: true

--- a/charts/rm-minio-bucket-api/Chart.yaml
+++ b/charts/rm-minio-bucket-api/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 0.0.3
+
+# Replaced with Crossplane
+deprecated: true

--- a/charts/rm-user-workspace/Chart.yaml
+++ b/charts/rm-user-workspace/Chart.yaml
@@ -15,13 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.0.0"
+
+# Replaced with newer workspace services
+deprecated: true
 
 dependencies:
   - name: "vs"

--- a/charts/storage/Chart.yaml
+++ b/charts/storage/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 1.0.0
+
+# No longer required
+deprecated: true

--- a/charts/uma-user-agent/Chart.yaml
+++ b/charts/uma-user-agent/Chart.yaml
@@ -15,10 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.5
+version: 1.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v1.2.3"
+
+# No longer used - APISIX plugin now used for proxy integration
+deprecated: true

--- a/charts/user-profile/Chart.yaml
+++ b/charts/user-profile/Chart.yaml
@@ -16,9 +16,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.13
+version: 1.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "v1.2"
+
+# No longer used
+deprecated: true

--- a/charts/workspace-ui/Chart.yaml
+++ b/charts/workspace-ui/Chart.yaml
@@ -15,9 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: v1.4.0
+
+# Service no longer used
+deprecated: true


### PR DESCRIPTION
These charts are disused and deleting them will simplify security scanning of the charts.

Marking them as deprecated before deletion is recommended as it tells anyone downstream that there won't be any new versions and makes it possible to reuse the name later.
