### PR TITLE
Fix null type in crossplane-keycloak-provider client

### DIFF
--- a/charts/iam-bb/Chart.yaml
+++ b/charts/iam-bb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0-dev12
+version: 2.1.0-dev13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/iam-bb/templates/keycloakrealmimport.yaml
+++ b/charts/iam-bb/templates/keycloakrealmimport.yaml
@@ -24,7 +24,7 @@ spec:
 {{- if .Values.iam.keycloak.configuration.provider.createServiceAccount }}
       - clientId: crossplane-keycloak-provider
         name: crossplane-keycloak-provider
-        type:
+        type: openid-connect
         enabled: true
         clientAuthenticatorType: client-secret
         secret: "${client_secret}"


### PR DESCRIPTION
This fix was made in response to the following error whilst following the deployment guide...

```
helm repo add eoepca-dev https://eoepca.github.io/helm-charts-dev
helm repo update eoepca-dev

helm upgrade --install iam eoepca-dev/iam-bb \
  --version 2.1.0-dev12 \
  --namespace iam \
  --create-namespace \
  --values generated-values.yaml
"eoepca-dev" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "eoepca-dev" chart repository
Update Complete. ⎈Happy Helming!⎈
level=WARN msg="upgrade failed" name=iam error="server-side apply failed for object iam/eoepca-realm k8s.keycloak.org/v2beta1, Kind=KeycloakRealmImport: KeycloakRealmImport.k8s.keycloak.org \"eoepca-realm\" is invalid: spec.realm.clients[0].type: Invalid value: \"null\": spec.realm.clients[0].type in body must be of type string: \"null\""
Error: UPGRADE FAILED: server-side apply failed for object iam/eoepca-realm k8s.keycloak.org/v2beta1, Kind=KeycloakRealmImport: KeycloakRealmImport.k8s.keycloak.org "eoepca-realm" is invalid: spec.realm.clients[0].type: Invalid value: "null": spec.realm.clients[0].type in body must be of type string: "null"
```

It seems to solve the deployment problem.
@w-scho Please check this is what would be intended